### PR TITLE
refactor: url 상수화

### DIFF
--- a/src/api/Question.api.ts
+++ b/src/api/Question.api.ts
@@ -1,10 +1,11 @@
+import { BACKEND_URLS } from "../constants/BackendUrls";
 import { ALL_CATEGORIES } from "../constants/Question";
 import { Category, Question } from "../models/Question.model";
 import { backendHttpClient } from "./BackendHttpClient.api";
 
 export async function fetchCategories() {
   const response = await backendHttpClient
-    .get<Category[]>(`api/categories`)
+    .get<Category[]>(BACKEND_URLS.CATEGORIES.ALL)
     .then((response) => response.data)
     .catch((error) => {
       throw error;
@@ -15,7 +16,7 @@ export async function fetchCategories() {
 
 export async function fetchQuestions(categoryId: number) {
   const response = await backendHttpClient
-    .get<Question[]>(`api/questions`, {
+    .get<Question[]>(BACKEND_URLS.QUESTIONS.ALL, {
       params: {
         categoryId: categoryId === ALL_CATEGORIES ? "" : categoryId,
       },

--- a/src/constants/BackendUrls.ts
+++ b/src/constants/BackendUrls.ts
@@ -1,0 +1,29 @@
+export const BACKEND_URLS = {
+  AUTH: {
+    LOGIN: "/api/auth/login",
+    LOGOUT: "/api/auth/logout",
+    SIGNUP: "/api/auth/signup",
+    CHECK_EMAIL: "/api/auth/check-email",
+    CHECK_NICKNAME: "/api/auth/check-nickname",
+  },
+  USERS: {
+    ME: "/api/users/me",
+    USER: "/api/users/:userId",
+  },
+  QUESTIONS: {
+    ALL: "/api/questions",
+    QUESTION: "/api/questions/:questionId",
+    WEEKLY: "/api/questions/weekly",
+  },
+  CATEGORIES: {
+    ALL: "/api/categories",
+  },
+  ANSWERS: {
+    MINE: "/api/answers/mine",
+    ANSWER: "/api/answers/:answerId",
+  },
+  FAVORITES: {
+    MINE: "/api/favorites/mine",
+    FAVORITE: "/api/favorites/:questionId",
+  },
+};

--- a/src/mocks/Categories.ts
+++ b/src/mocks/Categories.ts
@@ -1,9 +1,10 @@
 import { fakerKO as faker } from "@faker-js/faker";
 import { Category } from "../models/Question.model";
 import { http, HttpResponse } from "msw";
+import { BACKEND_URLS } from "../constants/BackendUrls";
 
 export const categories = http.get(
-  `${import.meta.env.VITE_BACKEND_BASE_URL}/api/categories`,
+  `${import.meta.env.VITE_BACKEND_BASE_URL}${BACKEND_URLS.CATEGORIES.ALL}`,
   () => {
     const categoriesData: Category[] = Array.from({ length: 20 }).map(
       (value, index) => ({

--- a/src/mocks/Questions.ts
+++ b/src/mocks/Questions.ts
@@ -1,9 +1,10 @@
 import { fakerKO as faker } from "@faker-js/faker";
 import { Question } from "../models/Question.model";
 import { http, HttpResponse } from "msw";
+import { BACKEND_URLS } from "../constants/BackendUrls";
 
 export const questions = http.get(
-  `${import.meta.env.VITE_BACKEND_BASE_URL}/api/questions`,
+  `${import.meta.env.VITE_BACKEND_BASE_URL}${BACKEND_URLS.QUESTIONS.ALL}`,
   () => {
     const questionsData: Question[] = Array.from({ length: 20 }).map(
       (value, index) => ({

--- a/src/utils/Url.ts
+++ b/src/utils/Url.ts
@@ -1,0 +1,11 @@
+export function replaceUrlParams(
+  url: string,
+  params: { [key: string]: string }
+): string {
+  for (const paramName in params) {
+    const regex = new RegExp(`:${paramName}`, "g");
+    url = url.replace(regex, params[paramName]);
+  }
+
+  return url;
+}


### PR DESCRIPTION
- URL이 변경될 때 API 코드, MSW 코드에 URL을 바꾸는게 번거로워 URL들을 한곳에 모아서 정리했습니다.
- URL 파라미터를 넣으려면 `utils/url.ts` 코드의 `replaceUrlParams()` 함수를 사용하면 됩니다.
- AxiosRequestConfig의 params(실제 작동은 query)와 혼동되는 것을 주의해야 합니다.