### PR TITLE
refactor: AnswersHistory 내부 컴포넌트를 Questions에서 별개의 Answers 컴포넌트로 분리

### DIFF
--- a/src/api/Answer.api.ts
+++ b/src/api/Answer.api.ts
@@ -1,11 +1,11 @@
 import { BACKEND_URLS } from "../constants/Urls";
-import { Question } from "../models/Question.model";
+import { Answer } from "../models/Answer.model";
 import { replaceUrlParams } from "../utils/Url";
 import { backendHttpClient } from "./BackendHttpClient.api";
 
 export async function fetchBasicAnsweredQuestions() {
   const response = await backendHttpClient
-    .get<Question[]>(BACKEND_URLS.ANSWERS.MINE)
+    .get<Answer[]>(BACKEND_URLS.ANSWERS.MINE)
     .then((response) => response.data)
     .catch((error) => {
       throw error;
@@ -16,7 +16,7 @@ export async function fetchBasicAnsweredQuestions() {
 
 export async function fetchWeeklyAnsweredQuestions() {
   const response = await backendHttpClient
-    .get<Question[]>(BACKEND_URLS.ANSWERS.WEEKLY)
+    .get<Answer[]>(BACKEND_URLS.ANSWERS.WEEKLY)
     .then((response) => response.data)
     .catch((error) => {
       throw error;

--- a/src/components/answersHistory/AnswerBox.tsx
+++ b/src/components/answersHistory/AnswerBox.tsx
@@ -1,0 +1,95 @@
+import styled from "styled-components";
+import { SlArrowRight } from "react-icons/sl";
+import { Link } from "react-router-dom";
+import { FRONTEND_URLS } from "../../constants/Urls";
+import { replaceUrlParams } from "../../utils/Url";
+
+export default AnswerBox;
+
+interface Props {
+  questionId: number;
+  answerId: number;
+  title: string;
+  categoryImagePath: string;
+  categoryName?: string;
+}
+
+function AnswerBox({
+  questionId,
+  answerId,
+  title,
+  categoryImagePath,
+  categoryName,
+}: Props) {
+  const link = replaceUrlParams(FRONTEND_URLS.ANSWER_EDIT, {
+    questionId: questionId.toString(),
+    answerId: answerId.toString(),
+  });
+
+  return (
+    <AnswerBoxStyle className="answer">
+      <Link className={`answer-link`} to={link}>
+        <div className="content">
+          <img src={categoryImagePath} alt={categoryName} />
+          <p>{title}</p>
+        </div>
+        <SlArrowRight className="icon-goto" />
+      </Link>
+    </AnswerBoxStyle>
+  );
+}
+
+const AnswerBoxStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  min-height: 60px;
+  background-color: #fbfbfb;
+  border: solid 1px #eff2f8;
+  border-radius: 10px;
+
+  .answer-link {
+    display: flex;
+    justify-content: space-between;
+
+    padding: 20px 15px;
+
+    color: inherit;
+    text-decoration: none;
+
+    align-items: center;
+  }
+
+  .content {
+    display: flex;
+
+    padding-right: 10px;
+    gap: 10px;
+
+    img {
+      width: 20px;
+      height: 20px;
+    }
+
+    p {
+      width: 210px;
+      font-weight: 400;
+    }
+  }
+
+  .answered {
+    pointer-events: none;
+    opacity: 0.5;
+  }
+
+  .icon-goto {
+    width: 15px;
+    height: 15px;
+    min-width: 15px;
+    min-height: 15px;
+  }
+
+  .answered-text {
+    font-size: 12px;
+  }
+`;

--- a/src/components/answersHistory/Answers.tsx
+++ b/src/components/answersHistory/Answers.tsx
@@ -1,0 +1,65 @@
+import styled from "styled-components";
+import { Swiper, SwiperSlide } from "swiper/react";
+import { SwiperOptions } from "swiper/types";
+import { FreeMode, Mousewheel } from "swiper/modules";
+import { Answer } from "../../models/Answer.model";
+import "swiper/css";
+import "swiper/css/free-mode";
+import AnswerBox from "./AnswerBox";
+
+export default Answers;
+
+interface Props {
+  className?: string;
+  answers: Answer[];
+  getCategoryName: (categoryId: number) => string;
+}
+
+function Answers({ className, answers, getCategoryName }: Props) {
+  const options: SwiperOptions = {
+    slidesPerView: "auto",
+    spaceBetween: 8,
+    direction: "vertical",
+    mousewheel: true,
+    freeMode: true,
+    modules: [FreeMode, Mousewheel],
+  };
+
+  return (
+    <AnswersStyle className={className}>
+      <Swiper {...options}>
+        {answers.map((answer) => {
+          const categoryName = getCategoryName(answer.question.categories[0]);
+
+          return (
+            <SwiperSlide key={answer.id}>
+              <AnswerBox
+                questionId={answer.id}
+                answerId={answer.id}
+                title={answer.question.title}
+                categoryImagePath={`../assets/categories/${answer.question.categories[0]}.png`}
+                categoryName={categoryName}
+              />
+            </SwiperSlide>
+          );
+        })}
+      </Swiper>
+    </AnswersStyle>
+  );
+}
+
+const AnswersStyle = styled.div`
+  padding-top: 54px;
+  height: 100%;
+
+  .swiper {
+    width: min(100%, 393px);
+    height: 100%;
+    padding: 0 25px;
+    z-index: 0;
+  }
+
+  .swiper-slide {
+    height: fit-content;
+  }
+`;

--- a/src/hooks/UseAnswer.ts
+++ b/src/hooks/UseAnswer.ts
@@ -3,23 +3,23 @@ import {
   fetchBasicAnsweredQuestions,
   fetchWeeklyAnsweredQuestions,
 } from "../api/Answer.api";
-import { Question } from "../models/Question.model";
+import { Answer } from "../models/Answer.model";
 
 export function useAnswer() {
   const [weeklyAnsweredQuestions, setWeeklyAnsweredQuestions] = useState<
-    Question[]
+    Answer[]
   >([]);
   const [basicAnsweredQuestions, setBasicAnsweredQuestions] = useState<
-    Question[]
+    Answer[]
   >([]);
 
   useEffect(() => {
     try {
-      fetchBasicAnsweredQuestions().then((questions) => {
-        setBasicAnsweredQuestions(questions);
+      fetchBasicAnsweredQuestions().then((answers) => {
+        setBasicAnsweredQuestions(answers);
       });
-      fetchWeeklyAnsweredQuestions().then((questions) => {
-        setWeeklyAnsweredQuestions(questions);
+      fetchWeeklyAnsweredQuestions().then((answers) => {
+        setWeeklyAnsweredQuestions(answers);
       });
     } catch (error) {
       console.error(error);

--- a/src/hooks/UseCategory.ts
+++ b/src/hooks/UseCategory.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import { Category } from "../models/Question.model";
+import { fetchCategories } from "../api/Question.api";
+
+export function useCategory() {
+  const [categories, setCategories] = useState<Category[]>([]);
+
+  useEffect(() => {
+    try {
+      fetchCategories().then((categories) => {
+        setCategories(categories);
+      });
+    } catch (error) {
+      console.error(error);
+    }
+  }, []);
+
+  const getCategoryName = (categoryId: number) => {
+    const category = categories.find((category) => category.id === categoryId);
+
+    return category !== undefined ? category.name : "";
+  };
+
+  return {
+    categories,
+    setCategories,
+    getCategoryName,
+  };
+}

--- a/src/hooks/UseQuestion.ts
+++ b/src/hooks/UseQuestion.ts
@@ -1,14 +1,15 @@
 import { useEffect, useState } from "react";
-import { Category, Question } from "../models/Question.model";
+import { Question } from "../models/Question.model";
 import {
   fetchCategories,
   fetchQuestions,
   fetchWeeklyQuestion,
 } from "../api/Question.api";
 import { ALL_CATEGORIES } from "../constants/Question";
+import { useCategory } from "./UseCategory";
 
 export function useQuestion() {
-  const [categories, setCategories] = useState<Category[]>([]);
+  const { categories, setCategories } = useCategory();
   const [questions, setQuestions] = useState<Question[]>([]);
   const [weeklyQuestion, setWeeklyQuestion] = useState<Question | null>(null);
 
@@ -48,17 +49,10 @@ export function useQuestion() {
     }
   };
 
-  const getCategoryName = (categoryId: number) => {
-    const category = categories.find((category) => category.id === categoryId);
-
-    return category !== undefined ? category.name : "";
-  };
-
   return {
     categories,
     questions,
     weeklyQuestion,
     updateQuestions,
-    getCategoryName,
   };
 }

--- a/src/mocks/Answers.ts
+++ b/src/mocks/Answers.ts
@@ -1,17 +1,19 @@
 import { http, HttpResponse } from "msw";
 import { BACKEND_URLS } from "../constants/Urls";
-import { Question } from "../models/Question.model";
+import { Answer } from "../models/Answer.model";
 import { fakerKO as faker } from "@faker-js/faker";
 
 export const basicAnsweredQuestions = http.get(
   `${import.meta.env.VITE_BACKEND_BASE_URL}${BACKEND_URLS.ANSWERS.MINE}`,
   () => {
-    const questionsData: Question[] = Array.from({ length: 20 }).map(
+    const questionsData: Answer[] = Array.from({ length: 20 }).map(
       (_, index) => ({
         id: index,
-        categories: [faker.helpers.rangeToNumber({ min: 0, max: 5 })],
-        title: faker.lorem.sentence(),
-        isAnswered: true,
+        question: {
+          id: faker.helpers.rangeToNumber({ min: 0, max: 1000 }),
+          title: faker.lorem.sentence(),
+          categories: [faker.helpers.rangeToNumber({ min: 0, max: 5 })],
+        },
       })
     );
 
@@ -22,12 +24,14 @@ export const basicAnsweredQuestions = http.get(
 export const weeklyAnsweredQuestions = http.get(
   `${import.meta.env.VITE_BACKEND_BASE_URL}${BACKEND_URLS.ANSWERS.WEEKLY}`,
   () => {
-    const questionsData: Question[] = Array.from({ length: 20 }).map(
+    const questionsData: Answer[] = Array.from({ length: 20 }).map(
       (_, index) => ({
         id: index,
-        categories: [faker.helpers.rangeToNumber({ min: 0, max: 5 })],
-        title: faker.lorem.sentence(),
-        isAnswered: true,
+        question: {
+          id: faker.helpers.rangeToNumber({ min: 0, max: 1000 }),
+          title: faker.lorem.sentence(),
+          categories: [faker.helpers.rangeToNumber({ min: 0, max: 5 })],
+        },
       })
     );
 

--- a/src/models/Answer.model.ts
+++ b/src/models/Answer.model.ts
@@ -1,0 +1,8 @@
+export interface Answer {
+  id: number;
+  question: {
+    id: number;
+    title: string;
+    categories: number[];
+  };
+}

--- a/src/pages/AnswerPage.tsx
+++ b/src/pages/AnswerPage.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { FaStar } from "react-icons/fa6";
 import ConfirmModal from "../components/common/ConfirmModal";
 import AlertModal from "../components/common/AlertModal";
-import { useQuestion } from "../hooks/UseQuestion";
+import { useCategory } from "../hooks/UseCategory";
 import { useEffect, useState } from "react";
 import { addFavorite, removeFavorite } from "../api/Favorite.api";
 import { useNavigate, useParams } from "react-router-dom";
@@ -14,7 +14,7 @@ type ModalType = "confirm" | "alert";
 
 function AnswerPage() {
   const questionId = Number(useParams<{ questionId: string }>().questionId);
-  const { getCategoryName } = useQuestion();
+  const { getCategoryName } = useCategory();
   const navigate = useNavigate();
 
   const [question, setQuestion] = useState<Question | undefined>(undefined);

--- a/src/pages/AnswersHistoryPage.tsx
+++ b/src/pages/AnswersHistoryPage.tsx
@@ -1,16 +1,16 @@
 import styled from "styled-components";
 import Tabs from "../components/common/Tabs";
 import { useState } from "react";
-import Questions from "../components/QuestionList/Questions";
-import { useQuestion } from "../hooks/UseQuestion";
 import { useAnswer } from "../hooks/UseAnswer";
+import Answers from "../components/answersHistory/Answers";
+import { useCategory } from "../hooks/UseCategory";
 
 export default AnswersHistoryPage;
 
 type TabType = "위클리" | "기본";
 
 function AnswersHistoryPage() {
-  const { getCategoryName } = useQuestion();
+  const { getCategoryName } = useCategory();
   const { basicAnsweredQuestions, weeklyAnsweredQuestions } = useAnswer();
   const [currentTab, setCurrentTab] = useState<TabType>("위클리");
 
@@ -27,14 +27,13 @@ function AnswersHistoryPage() {
         onClickTab={handleClickTab}
         currentTab={currentTab}
       />
-      <Questions
-        className="questions"
-        questions={
+      <Answers
+        className="answers"
+        answers={
           currentTab === "위클리"
             ? weeklyAnsweredQuestions
             : basicAnsweredQuestions
         }
-        questionsType="Answered"
         getCategoryName={getCategoryName}
       />
     </AnswersHistoryStyle>
@@ -50,7 +49,7 @@ const AnswersHistoryStyle = styled.div`
   flex-direction: column;
   overflow: hidden;
 
-  .questions {
+  .answers {
     padding-top: 68px;
   }
 `;

--- a/src/pages/FavoriteQuestionListPage.tsx
+++ b/src/pages/FavoriteQuestionListPage.tsx
@@ -2,13 +2,13 @@ import styled from "styled-components";
 import Tabs from "../components/common/Tabs";
 import { useState } from "react";
 import Questions from "../components/QuestionList/Questions";
-import { useQuestion } from "../hooks/UseQuestion";
+import { useCategory } from "../hooks/UseCategory";
 import { useFavorite } from "../hooks/UseFavorite";
 
 export default FavoriteQuestionListPage;
 
 function FavoriteQuestionListPage() {
-  const { getCategoryName } = useQuestion();
+  const { getCategoryName } = useCategory();
   const { favoriteQuestions } = useFavorite();
   const [currentTab, setCurrentTab] = useState("위클리");
 

--- a/src/pages/QuestionListPage.tsx
+++ b/src/pages/QuestionListPage.tsx
@@ -3,13 +3,14 @@ import styled from "styled-components";
 import Categories from "../components/QuestionList/Categories.tsx";
 import Questions from "../components/QuestionList/Questions.tsx";
 import { useQuestion } from "../hooks/UseQuestion.ts";
+import { useCategory } from "../hooks/UseCategory.ts";
 import { ALL_CATEGORIES } from "../constants/Question.ts";
 
 export default QuestionListPage;
 
 function QuestionListPage(): JSX.Element {
-  const { categories, questions, updateQuestions, getCategoryName } =
-    useQuestion();
+  const { categories, questions, updateQuestions } = useQuestion();
+  const { getCategoryName } = useCategory();
   const [activeCategoryId, setActiveCategoryId] =
     useState<number>(ALL_CATEGORIES);
 


### PR DESCRIPTION
- Answers, AnswerBox 컴포넌트를 분리
  - 구현 복잡도가 상승해 Questions, QuestionBox를 공통으로 사용하지 않도록 분리
- AnswerBox가 수정한 ANSWER_EDIT 링크에 대응하도록 코드 추가
- Questions, QuestionBox의 로직 제거는 작업하지 않았습니다.