### PR TITLE
FEAT : RankingMainPage 닉네임 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/error-message": "^2.0.1",
+        "@tanstack/react-query": "^5.74.3",
         "axios": "^1.8.1",
         "pretendard": "^1.3.9",
         "react": "^19.0.0",
@@ -1536,6 +1537,32 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.74.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.74.3.tgz",
+      "integrity": "sha512-Mqk+5o3qTuAiZML248XpNH8r2cOzl15+LTbUsZQEwvSvn1GU4VQhvqzAbil36p+MBxpr/58oBSnRzhrBevDhfg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.74.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.74.3.tgz",
+      "integrity": "sha512-QrycUn0wxjVPzITvQvOxFRdhlAwIoOQSuav7qWD4SWCoKCdLbyRZ2vji2GuBq/glaxbF4wBx3fqcYRDOt8KDTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.74.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hookform/error-message": "^2.0.1",
+    "@tanstack/react-query": "^5.74.3",
     "axios": "^1.8.1",
     "pretendard": "^1.3.9",
     "react": "^19.0.0",

--- a/src/hooks/useMyUserData.ts
+++ b/src/hooks/useMyUserData.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchMyUserData } from "../api/User.api";
+
+export const useMyUserData = () => {
+  return useQuery({
+    queryKey: ["myUserData"],
+    queryFn: fetchMyUserData,
+    staleTime: 1000 * 60 * 5,
+  });
+};

--- a/src/hooks/useMyUserData.ts
+++ b/src/hooks/useMyUserData.ts
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { fetchMyUserData } from "../api/User.api";
 
-export const useMyUserData = () => {
+export function useMyUserData() {
   return useQuery({
     queryKey: ["myUserData"],
     queryFn: fetchMyUserData,
     staleTime: 1000 * 60 * 5,
   });
-};
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,9 @@ import { createRoot } from "react-dom/client";
 import { worker } from "./mocks/Worker.ts";
 import App from "./App.tsx";
 import "sanitize.css";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
 
 switch (import.meta.env.MODE) {
   case "development":
@@ -23,7 +26,9 @@ switch (import.meta.env.MODE) {
 function createReactApp() {
   createRoot(document.getElementById("root")!).render(
     <StrictMode>
-      <App />
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
     </StrictMode>
   );
 }

--- a/src/pages/RankingMainPage.tsx
+++ b/src/pages/RankingMainPage.tsx
@@ -3,15 +3,22 @@ import styled from "styled-components";
 import RankingProfile from "../components/common/Profile/RankingProfile";
 import CommonProfile from "../components/common/Profile/CommonProfile";
 import { FRONTEND_URLS } from "../constants/Urls";
+import { useMyUserData } from "../hooks/useMyUserData";
 
 function RankingMainPage() {
+  const { data, isLoading, error } = useMyUserData();
+
+  if (isLoading) return <div>로딩 중...</div>;
+  if (error) return <div>에러 발생!</div>;
+  if (!data) return <div>데이터 없음</div>;
+
   return (
     <RankingMainPageStyle>
       <div className="profile">
         <div className="profile-box">
           <CommonProfile
             profileImg="../public/profile-image.png"
-            username="BulanPing"
+            username={data.nickname}
             position="Front-End"
             level={5}
           />

--- a/src/pages/RankingMainPage.tsx
+++ b/src/pages/RankingMainPage.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import RankingProfile from "../components/common/Profile/RankingProfile";
 import CommonProfile from "../components/common/Profile/CommonProfile";
 import { FRONTEND_URLS } from "../constants/Urls";
-import { useMyUserData } from "../hooks/useMyUserData";
+import { useMyUserData } from "../hooks/UseMyUserData";
 
 function RankingMainPage() {
   const { data, isLoading, error } = useMyUserData();

--- a/src/pages/RankingMainPage.tsx
+++ b/src/pages/RankingMainPage.tsx
@@ -50,9 +50,9 @@ const answerRankingUsers = [
 function RankingMainPage() {
   const { data, isLoading, error } = useMyUserData();
 
-  if (isLoading) return <div>로딩 중...</div>;
-  if (error) return <div>에러 발생!</div>;
-  if (!data) return <div>데이터 없음</div>;
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+  if (!data) return <div>No data available. Please try again later.</div>;
 
   return (
     <RankingMainPageStyle>

--- a/src/routers/RouterObject.tsx
+++ b/src/routers/RouterObject.tsx
@@ -90,6 +90,6 @@ export const routerObjects: RouteObject[] = [
 const routerPaths = routerObjects.map((route) => route.path);
 const missingUrls = requiredUrls.filter((url) => !routerPaths.includes(url));
 
-// if (0 < missingUrls.length) {
-//   throw new Error(`Missing routes for URLs: ${missingUrls.join(", ")}`);
-// }
+if (0 < missingUrls.length) {
+  throw new Error(`Missing routes for URLs: ${missingUrls.join(", ")}`);
+}

--- a/src/routers/RouterObject.tsx
+++ b/src/routers/RouterObject.tsx
@@ -90,6 +90,6 @@ export const routerObjects: RouteObject[] = [
 const routerPaths = routerObjects.map((route) => route.path);
 const missingUrls = requiredUrls.filter((url) => !routerPaths.includes(url));
 
-if (0 < missingUrls.length) {
-  throw new Error(`Missing routes for URLs: ${missingUrls.join(", ")}`);
-}
+// if (0 < missingUrls.length) {
+//   throw new Error(`Missing routes for URLs: ${missingUrls.join(", ")}`);
+// }


### PR DESCRIPTION
- 리액트쿼리 사용을 위해 tanstack 라이브러리 설치
- 쿼리 사용을 위해 main.tsx에 QueryClientProvider 추가
- useMyUserData : 로그인한 회원정보를 불러오는 커스텀 훅 구현
- RankingMainPage의 닉네임을 로그인한 회원의 닉네임으로 수정
