### PR TITLE
feat: useAuth에 프로필 이미지 변경 추가하여 me에 즉시반영

### DIFF
--- a/src/hooks/UseAuth.ts
+++ b/src/hooks/UseAuth.ts
@@ -6,6 +6,7 @@ import {
   changeNickname,
   changePassword,
   fetchMyUserData,
+  uploadProfile,
 } from "../api/User.api";
 import { UserBasicInfo } from "../models/User.model";
 
@@ -22,6 +23,7 @@ interface UseAuthReturn {
     oldPassword: string,
     newPassword: string
   ) => Promise<void>;
+  handleChangeProfileImage: (file: File) => Promise<void>;
 }
 
 export function useAuth(): UseAuthReturn {
@@ -142,6 +144,22 @@ export function useAuth(): UseAuthReturn {
     [isAuthenticated, me, updateAuthState, handleError]
   );
 
+  const handleChangeProfileImage = useCallback(
+    async (file: File): Promise<void> => {
+      try {
+        updateAuthState(isAuthenticated, me, true);
+        const profileImageUrl = await uploadProfile(file);
+        if (me) {
+          updateAuthState(isAuthenticated, { ...me, profileImageUrl }, false);
+        }
+      } catch (err: unknown) {
+        handleError(err, "프로필 이미지 변경에 실패했습니다.");
+        updateAuthState(isAuthenticated, me, false);
+      }
+    },
+    [isAuthenticated, me, updateAuthState, handleError]
+  );
+
   return {
     isAuthenticated,
     isLoading,
@@ -152,5 +170,6 @@ export function useAuth(): UseAuthReturn {
     handleLogout,
     handleChangeNickname,
     handleChangePassword,
+    handleChangeProfileImage,
   };
 }

--- a/src/pages/Mypage/SettingsProfile.tsx
+++ b/src/pages/Mypage/SettingsProfile.tsx
@@ -10,7 +10,6 @@ import MyProfileAddBtn from "../../assets/mypage/MyProfileAddButton.png";
 import InputField from "../../components/common/Input/Input";
 import { ModalType } from "../RecordAnswerPage";
 import { useAuth } from "../../hooks/UseAuth";
-import { uploadProfile } from "../../api/User.api";
 import { MAX_PROFILE_IMAGE_SIZE } from "../../constants/User";
 
 export interface SignUpInputs {
@@ -20,7 +19,7 @@ export interface SignUpInputs {
 
 function SettingProfile() {
   const navigate = useNavigate();
-  const { me, setMe, handleLogout } = useAuth();
+  const { me, handleLogout, handleChangeProfileImage } = useAuth();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -76,13 +75,7 @@ function SettingProfile() {
       }
 
       setIsLoading(true);
-      const profileUrl = await uploadProfile(file);
-      // 프로필 이미지 업데이트
-      if (me && setMe) {
-        setMe({ ...me, profileImageUrl: profileUrl });
-      }
-
-      // 성공 메시지 표시
+      await handleChangeProfileImage(file);
       setError("프로필 이미지가 성공적으로 업데이트되었습니다.");
     } catch (error) {
       console.error("프로필 업로드 실패:", error);


### PR DESCRIPTION
- useAuth 훅에 handleChangeProfileImage 함수 추가
- SettingsProfile 컴포넌트에서 프로필 이미지 변경 로직을 handleChangeProfileImage로 통합